### PR TITLE
Introduce disabling envs for namespace resources

### DIFF
--- a/controllers/stardoginstance_controller.go
+++ b/controllers/stardoginstance_controller.go
@@ -51,6 +51,10 @@ func (r *StardogInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{Requeue: true, RequeueAfter: ReconFreqErr}, err
 	}
 
+	if environmentDisabled(stardogInstance) {
+		return ctrl.Result{Requeue: false}, nil
+	}
+
 	sir := &StardogInstanceReconciliation{
 		reconciliationContext: &ReconciliationContext{
 			context:       ctx,

--- a/controllers/stardogrole_controller.go
+++ b/controllers/stardogrole_controller.go
@@ -54,6 +54,10 @@ func (r *StardogRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{Requeue: true, RequeueAfter: ReconFreqErr}, err
 	}
 
+	if environmentDisabled(stardogRole) {
+		return ctrl.Result{Requeue: false}, nil
+	}
+
 	srr := &StardogRoleReconciliation{
 		reconciliationContext: &ReconciliationContext{
 			context:       ctx,

--- a/controllers/stardoguser_controller.go
+++ b/controllers/stardoguser_controller.go
@@ -51,6 +51,10 @@ func (r *StardogUserReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{Requeue: true, RequeueAfter: ReconFreqErr}, err
 	}
 
+	if environmentDisabled(stardogUser) {
+		return ctrl.Result{Requeue: false}, nil
+	}
+
 	sur := &StardogUserReconciliation{
 		reconciliationContext: &ReconciliationContext{
 			context:       ctx,


### PR DESCRIPTION
## Summary

* This PR makes possible for namespace stardog custom resources to disable specific environments.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
