### PR TITLE
Fix credentials not found during deletion

### DIFF
--- a/controllers/stardoguser_controller.go
+++ b/controllers/stardoguser_controller.go
@@ -144,15 +144,9 @@ func (r *StardogUserReconciler) finalize(sur *StardogUserReconciliation) error {
 		return err
 	}
 
-	r.Log.V(1).Info("retrieving user credentials from Secret", "secret", spec.Credentials.Namespace+"/"+spec.Credentials.SecretRef)
-	username, _, err := rc.getCredentials(r.Client, spec.Credentials, namespace)
+	_, err = rc.stardogClient.Users.RemoveUser(model_users.NewRemoveUserParams().WithUser(sur.resource.Name), auth)
 	if err != nil {
-		return err
-	}
-
-	_, err = rc.stardogClient.Users.RemoveUser(model_users.NewRemoveUserParams().WithUser(username), auth)
-	if err != nil {
-		return fmt.Errorf("cannot remove Stardog user %s/%s: %v", namespace, username, err)
+		return fmt.Errorf("cannot remove Stardog user %s/%s: %v", namespace, sur.resource.Name, err)
 	}
 	return nil
 }

--- a/controllers/stardoguser_controller_test.go
+++ b/controllers/stardoguser_controller_test.go
@@ -99,7 +99,7 @@ func Test_deleteStardogUser(t *testing.T) {
 					Return(users.NewRemoveUserNoContent(), errors.New("cannot remove user"))
 			},
 			expectedFinalizers: []string{userFinalizer},
-			err:                errors.New("cannot remove Stardog user namespace-test/dXNlcg==: cannot remove user"),
+			err:                errors.New("cannot remove Stardog user namespace-test/user-test: cannot remove user"),
 		},
 	}
 


### PR DESCRIPTION
## Summary

* Fixed StardogUsers deletion being blocked by credentials not found error.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
