### PR TITLE
Fix graph permissions

### DIFF
--- a/controllers/organization_controller.go
+++ b/controllers/organization_controller.go
@@ -460,12 +460,12 @@ func getGraphPermissions(org *stardogv1beta1.Organization, namedGraphPrefix, dbN
 		ngPerm := []models.Permission{
 			{
 				Action:       pointer.String("READ"),
-				Resource:     []string{fullNameNG, dbName},
+				Resource:     []string{dbName, fullNameNG},
 				ResourceType: pointer.String("named-graph"),
 			},
 			{
 				Action:       pointer.String("WRITE"),
-				Resource:     []string{fullNameNG, dbName},
+				Resource:     []string{dbName, fullNameNG},
 				ResourceType: pointer.String("named-graph"),
 			},
 		}


### PR DESCRIPTION
## Summary

* For named graphs the database has to be first in the list of resources in the permission object.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
